### PR TITLE
Fix schedule draggable-ness

### DIFF
--- a/app/views/sessions/_session_block.html.erb
+++ b/app/views/sessions/_session_block.html.erb
@@ -1,4 +1,4 @@
-<div id="<%=session.id %> class="<%=logged_in? ? 'draggablesessionblock' : 'sessionblock' %>">
+<div id="<%=session.id %>" class="<%=logged_in? ? 'draggablesessionblock' : 'sessionblock' %>">
   <strong><%= render_session_name(session).html_safe %></strong>
   <br />
   <%= link_to session.speaker.name, session.speaker %>


### PR DESCRIPTION
Fix the draggable/droppable session page by fixing a typo in the session view, which fixes the classname, which allows the jQuery to find the div, which makes it draggable.
